### PR TITLE
chore: add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+composer.lock

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -1,0 +1,15 @@
+namespace: Passioneight\Bundle\PhpUtilitiesBundle\Tests
+suites:
+    unit:
+        path: unit
+
+settings:
+    shuffle: true
+    lint: true
+
+paths:
+    tests: tests
+    output: tests/_output
+    support: tests/_support
+    data: tests
+     

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,18 @@
 {
-  "name": "passioneight/php-utilities",
-  "type": "pimcore-bundle",
-  "license": "GPL-3.0",
-  "autoload": {
-    "psr-4": {
-      "Passioneight\\Bundle\\PhpUtilitiesBundle\\": "src/"
+    "name": "passioneight/php-utilities",
+    "type": "pimcore-bundle",
+    "license": "GPL-3.0",
+    "require-dev": {
+      "codeception/module-asserts": "^1.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Passioneight\\Bundle\\PhpUtilitiesBundle\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Passioneight\\Bundle\\PhpUtilitiesBundle\\Tests\\": "tests/"
+        }
     }
-  }
 }

--- a/tests/Mockup/ProductTypeMockup.php
+++ b/tests/Mockup/ProductTypeMockup.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Passioneight\Bundle\PhpUtilitiesBundle\Tests\Mockup;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Constant\Constant;
+
+class ProductTypeMockup extends Constant
+{
+    const ARTICLE = "article";
+    const SKU = "sku";
+}

--- a/tests/unit/Constant/ConstantTest.php
+++ b/tests/unit/Constant/ConstantTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace Passioneight\Bundle\PhpUtilities\Tests\Constant;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Tests\Mockup\ProductTypeMockup;
+
+class ConstantTest extends \Codeception\Test\Unit
+{
+    public function testConstant()
+    {
+        $constants = ProductTypeMockup::getAll();
+
+        $this->assertTrue(is_array($constants), "Return value must be an array.");
+
+        foreach ($constants as $name => $value) {
+            $this->assertTrue(ProductTypeMockup::has($value), "The value '$value' is not available.");
+            $this->assertEquals($value, ProductTypeMockup::get($name), "Fetching the value based on the constants name failed.");
+        }
+    }
+}

--- a/tests/unit/Service/MethodUtilityTest.php
+++ b/tests/unit/Service/MethodUtilityTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Passioneight\Bundle\PhpUtilitiesBundle\Tests\Service;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Service\Utility\MethodUtility;
+
+class MethodUtilityTest extends \Codeception\Test\Unit
+{
+    public function testCreateGetter()
+    {
+        $this->assertEquals("getTest", MethodUtility::createGetter("Test"));
+        $this->assertEquals("getTest", MethodUtility::createGetter("test"));
+        $this->assertEquals("getTest", MethodUtility::createGetter(" test"));
+    }
+
+    public function testCreateSetter()
+    {
+        $this->assertEquals("setTest", MethodUtility::createSetter("Test"));
+        $this->assertEquals("setTest", MethodUtility::createSetter("test"));
+        $this->assertEquals("setTest", MethodUtility::createSetter(" test"));
+    }
+
+    public function testCreateHasser()
+    {
+        $this->assertEquals("hasTest", MethodUtility::createHasser("Test"));
+        $this->assertEquals("hasTest", MethodUtility::createHasser("test"));
+        $this->assertEquals("hasTest", MethodUtility::createHasser(" test"));
+    }
+
+    public function testCreateIsser()
+    {
+        $this->assertEquals("isTest", MethodUtility::createIsser("Test"));
+        $this->assertEquals("isTest", MethodUtility::createIsser("test"));
+        $this->assertEquals("isTest", MethodUtility::createIsser(" test"));
+    }
+
+    public function testIsGetter()
+    {
+        $this->assertTrue(MethodUtility::isGetter(MethodUtility::createGetter("Test")));
+    }
+
+    public function testIsSetter()
+    {
+        $this->assertTrue(MethodUtility::isSetter(MethodUtility::createSetter("Test")));
+    }
+
+    public function testIsHasser()
+    {
+        $this->assertTrue(MethodUtility::isHasser(MethodUtility::createHasser("Test")));
+    }
+
+    public function testIsIsser()
+    {
+        $this->assertTrue(MethodUtility::isIsser(MethodUtility::createIsser("Test")));
+    }
+}

--- a/tests/unit/Service/NamespaceUtilityTest.php
+++ b/tests/unit/Service/NamespaceUtilityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Passioneight\Bundle\PhpUtilitiesBundle\Tests\Service;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Service\Utility\NamespaceUtility;
+use Passioneight\Bundle\PhpUtilitiesBundle\Tests\Mockup\ProductTypeMockup;
+
+class NamespaceUtilityTest extends \Codeception\Test\Unit
+{
+    public function testGetClassNameFromObject()
+    {
+        $this->assertEquals("ProductTypeMockup", NamespaceUtility::getClassNameFromObject(new ProductTypeMockup()));
+    }
+
+    public function testGetClassNameFromNamespace()
+    {
+        $this->assertEquals("ProductTypeMockup", NamespaceUtility::getClassNameFromNamespace(ProductTypeMockup::class));
+        $this->assertEquals(NamespaceUtility::getClassNameFromObject(new ProductTypeMockup()), NamespaceUtility::getClassNameFromNamespace(ProductTypeMockup::class));
+    }
+
+    public function testGetNamespaceForClass()
+    {
+        $namespace = "Passioneight\\Bundle\\PhpUtilitiesBundle\\Service\\Utility";
+        $this->assertEquals($namespace, NamespaceUtility::getNamespaceForClass(NamespaceUtility::class));
+    }
+
+    public function testGetPartsFromNamespace()
+    {
+        $namespace = "Passioneight\\Bundle\\PhpUtilitiesBundle\\Service\\Utility";
+
+        $this->assertIsArray(NamespaceUtility::getPartsFromNamespace($namespace));
+        $this->assertIsArray(NamespaceUtility::getPartsFromNamespace(NamespaceUtility::class));
+    }
+
+    public function testJoin()
+    {
+        $namespace = "Passioneight\\Bundle\\PhpUtilitiesBundle\\Service\\Utility";
+
+        $this->assertEquals($namespace, NamespaceUtility::join("Passioneight", "Bundle", "PhpUtilitiesBundle", "Service", "Utility"));
+        $this->assertEquals($namespace, NamespaceUtility::join(...["Passioneight", "Bundle", "PhpUtilitiesBundle", "Service", "Utility"]));
+    }
+}

--- a/tests/unit/Service/PathUtilityTest.php
+++ b/tests/unit/Service/PathUtilityTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Passioneight\Bundle\PhpUtilitiesBundle\Tests\Service;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Service\Utility\PathUtility;
+
+class PathUtilityTest extends \Codeception\Test\Unit
+{
+    public function testAddTrailingSlash()
+    {
+        $this->assertEquals("path/to/test" . DIRECTORY_SEPARATOR, PathUtility::addTrailingSlash("path/to/test"));
+        $this->assertEquals("path/to/test/" . DIRECTORY_SEPARATOR, PathUtility::addTrailingSlash("path/to/test/"));
+    }
+
+    public function testAddLeadingSlash()
+    {
+        $this->assertEquals(DIRECTORY_SEPARATOR . "path/to/test", PathUtility::addLeadingSlash("path/to/test"));
+        $this->assertEquals(DIRECTORY_SEPARATOR . "/path/to/test", PathUtility::addLeadingSlash("/path/to/test"));
+    }
+
+    public function testEnsurePath()
+    {
+        $path = "tests" . DIRECTORY_SEPARATOR . "_temp";
+        $this->assertTrue(PathUtility::ensurePath($path));
+
+        rmdir($path);
+    }
+
+    public function testGetPathFromFile()
+    {
+        $this->assertEquals("path" . DIRECTORY_SEPARATOR . "to", PathUtility::getPathFromFile("path" . DIRECTORY_SEPARATOR . "to" . DIRECTORY_SEPARATOR . "File.pdf"));
+    }
+
+    public function testJoin()
+    {
+        $path = "Passioneight" . DIRECTORY_SEPARATOR . "Bundle" . DIRECTORY_SEPARATOR . "PhpUtilitiesBundle" . DIRECTORY_SEPARATOR . "Service" . DIRECTORY_SEPARATOR . "Utility";
+
+        $this->assertEquals($path, PathUtility::join("Passioneight", "Bundle", "PhpUtilitiesBundle", "Service", "Utility"));
+        $this->assertEquals($path, PathUtility::join(...["Passioneight", "Bundle", "PhpUtilitiesBundle", "Service", "Utility"]));
+    }
+}

--- a/tests/unit/Service/UrlUtilityTest.php
+++ b/tests/unit/Service/UrlUtilityTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace Passioneight\Bundle\PhpUtilitiesBundle\Tests\Service;
+
+use Passioneight\Bundle\PhpUtilitiesBundle\Constant\Php;
+use Passioneight\Bundle\PhpUtilitiesBundle\Service\Utility\UrlUtility;
+
+class UrlUtilityTest extends \Codeception\Test\Unit
+{
+    public function testEnsureTrailingSlash()
+    {
+        $this->assertEquals("/url/to/test/", UrlUtility::ensureTrailingSlash("/url/to/test"));
+        $this->assertEquals("/url/to/test/", UrlUtility::ensureTrailingSlash("/url/to/test/"));
+        $this->assertEquals("/url/to/test/", UrlUtility::ensureTrailingSlash("/url/to/test//"));
+    }
+
+    public function testRemoveTrailingSlash()
+    {
+        $this->assertEquals("/url/to/test", UrlUtility::removeTrailingSlash("/url/to/test"));
+        $this->assertEquals("/url/to/test", UrlUtility::removeTrailingSlash("/url/to/test/"));
+        $this->assertEquals("/url/to/test", UrlUtility::removeTrailingSlash("/url/to/test//"));
+    }
+
+    public function testEnsureLeadingSlash()
+    {
+        $this->assertEquals("/url/to/test", UrlUtility::ensureLeadingSlash("url/to/test"));
+        $this->assertEquals("/url/to/test", UrlUtility::ensureLeadingSlash("/url/to/test"));
+        $this->assertEquals("/url/to/test", UrlUtility::ensureLeadingSlash("//url/to/test"));
+    }
+
+    public function testRemoveLeadingSlash()
+    {
+        $this->assertEquals("url/to/test", UrlUtility::removeLeadingSlash("url/to/test"));
+        $this->assertEquals("url/to/test", UrlUtility::removeLeadingSlash("/url/to/test"));
+        $this->assertEquals("url/to/test", UrlUtility::removeLeadingSlash("//url/to/test"));
+    }
+
+    public function testGetEndpointFromUrl()
+    {
+        $this->assertEquals("test", UrlUtility::getEndpointFromUrl("url/to/test"));
+        $this->assertEquals("test", UrlUtility::getEndpointFromUrl("/url/to/test"));
+        $this->assertEquals("endpoint", UrlUtility::getEndpointFromUrl("url/to/test//endpoint"));
+        $this->assertEmpty( UrlUtility::getEndpointFromUrl("url/to/test/"));
+        $this->assertEmpty(UrlUtility::getEndpointFromUrl("url/to/test//"));
+    }
+
+    public function testGetPartsFromUrl()
+    {
+        $this->assertIsArray(UrlUtility::getPartsFromUrl("url/to/test"));
+        $this->assertEquals(["url", "to", "test"], UrlUtility::getPartsFromUrl("url/to/test"));
+        $this->assertEquals(["", "url", "to", "test"], UrlUtility::getPartsFromUrl("/url/to/test"));
+        $this->assertEquals(["url", "to", "test", ""], UrlUtility::getPartsFromUrl("url/to/test/"));
+        $this->assertEquals(["", "url", "to", "test", ""], UrlUtility::getPartsFromUrl("/url/to/test/"));
+        $this->assertEquals(["url", "to", "test"], UrlUtility::getPartsFromUrl("url/to/test?param=test&param2=test"));
+        $this->assertEquals(["url", "to", "test", "", "endpoint"], UrlUtility::getPartsFromUrl("url/to/test//endpoint"));
+    }
+
+    public function testGetUrlWithoutQueryString()
+    {
+        $this->assertEquals("url/to/test", UrlUtility::getUrlWithoutQueryString("url/to/test?param=test&param2=test"));
+    }
+
+    public function testJoin()
+    {
+        $this->assertEquals("url/to/test", UrlUtility::join("url", "to", "test"));
+        $this->assertEquals("url/to/test/", UrlUtility::join("url", "to", "test", ""));
+        $this->assertEquals("/url/to/test", UrlUtility::join("", "url", "to", "test"));
+        $this->assertEquals("//url/to/test", UrlUtility::join("", "", "url", "to", "test"));
+        $this->assertEquals("url/to/test//", UrlUtility::join("url", "to", "test", "", ""));
+        $this->assertEquals("url/to//test", UrlUtility::join("url", "to", "", "test"));
+        $this->assertEquals("url/to/test", UrlUtility::join(...["url", "to", "test"]));
+    }
+
+    public function testAppendToUrl()
+    {
+        $this->assertEquals("url/to/test?param=test", UrlUtility::appendToUrl("url/to/test", "param=test"));
+        $this->assertEquals("url/to/test?param=test&param1=test", UrlUtility::appendToUrl("url/to/test?param=test", "param1=test", Php::URL_DELIMITER_QUERY_STRING));
+        $this->assertEquals("url/to/test/endpoint", UrlUtility::appendToUrl("url/to/test", "endpoint", Php::URL_DELIMITER));
+    }
+}


### PR DESCRIPTION
Adds the complete suit of unit tests for this bundle.

> Note that code that will be removed in future versions, such as `StringUtility`, is not covered as this would not make much sense. Also see #7 and #6 .